### PR TITLE
Remove vestigial renderer option

### DIFF
--- a/bin/war_paint
+++ b/bin/war_paint
@@ -10,18 +10,9 @@ options = {}                            # These lines set up default values and 
 default_rows = 5
 default_cols = 5
 
-
-
 OptionParser.new do |opts|                         # Creates a new OpertionParser object with a block argument for `opts`      
   opts.banner = "Usage: war_paint [options]"       # This part is only really useful if I'm using the --help flag in the terminal 
 
-
-
-
-
-  opts.on("-x", "--curses", "Use the curses renderer") do    # The command line options for renderers. 
-    options[:renderer] = CursesRenderer                      # Sets the :renderer key in the options hash to CursesRenderer.
-  end
 
   opts.on("-r ROWS", "--rows ROWS", Integer, "Number of rows (default: #{default_rows})") do |rows|    # Command line options for rows that must be a number type 
     options[:rows] = rows                                    # Sets the :rows key in the options hash to the rows provided.                                 
@@ -32,13 +23,11 @@ OptionParser.new do |opts|                         # Creates a new OpertionParse
   end
 end.parse!                                         # The end keyword chains parse! because it's a Ruby pattern for blocks that accept arguments. It parses the command line arguments. 
 
-
-renderer_class = options[:renderer] || CursesRenderer
 rows = options[:rows] || default_rows
 cols = options[:cols] || default_cols
 
 board = Board.new(rows, cols)
-renderer = renderer_class.new(board)
+renderer = CursesRenderer.new(board)
 renderer.play!
 
 


### PR DESCRIPTION
This PR:
- https://github.com/erikamaker/war-paint/pull/10
removed the terminal renderer, and as I don't think we plan on introducing another the option to switch renderers is currently (and likely for a long time) superfluous.