### PR TITLE
Rough testing for color updates depending on agent playing

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,5 +1,6 @@
 class Board
   attr_reader :grid
+  attr_accessor :agent
 
   def initialize(rows, cols)
     @grid = Array.new(rows) { Array.new(cols) { Cell.new } }
@@ -15,6 +16,19 @@ class Board
 
   def paint!(row, col)
     @grid[row][col].paint!
+    agent_is_player
+  end
+
+  def agent_is_cpu
+    @agent = :cpu
+  end
+
+  def agent_is_player
+    @agent = :player
+  end
+
+  def whose_turn_is_it?
+    print @agent
   end
 
   def game_over?

--- a/lib/cpu.rb
+++ b/lib/cpu.rb
@@ -7,6 +7,7 @@ class Cpu
             row.each_with_index do |cell, column_index|
                 if !cell.painted?
                     @board.paint!(row_index,column_index)
+                    @board.agent_is_cpu
                     return
                 end
             end

--- a/lib/curses_renderer.rb
+++ b/lib/curses_renderer.rb
@@ -41,7 +41,10 @@ class CursesRenderer
         update_selection(key)
       elsif painting?(key)
         @board.paint!(@selected[0], @selected[1])
+        @board.whose_turn_is_it?
+
         @cpu_player.cpus_turn
+        @board.whose_turn_is_it?
       end
     end
 


### PR DESCRIPTION
In the Board class, I've added an instance variable @agent, that signifies which agent (player vs CPU) is playing. I've also added a few methods to toggle whose turn it is, as well as reading that result. The `paint!` method now automatically assigns the @agent as player, and the Cpu instance toggles it during its `cpus_turn` method. 

This lets me see who is changing the cell and at one point. I want to use this instance variable to toggle the color pairing constant. The issue I'm running into is: 

```

  def parse_color
    if @board.whose_turn_is_it? == :player
        return PLAYER_COLOR
    else
        return CPU_COLOR
    end
  end

  def draw_cell(cell, row, col)
    box = selected?(row, col) ? selected_box : unselected_box    # <--- implementation here
    color = cell.painted? ? parse_color : UNPAINTED_COLOR
... 
```

Caused every painted cell to turn blue. I'm going to keep thinking on this, unless you can help tell me where I'm going wrong? 